### PR TITLE
Fix crashes on Node (from stringifying invalid ObjectIds, and from no document global)

### DIFF
--- a/src/main/javascript/Objectid.js
+++ b/src/main/javascript/Objectid.js
@@ -9,6 +9,8 @@
 *
 */
 
+if (!document) var document = { cookie: '' }; // fix crashes on node
+
 /**
  * Javascript class that mimics how WCF serializes a object of type MongoDB.Bson.ObjectId
  * and converts between that format and the standard 24 character representation.
@@ -94,6 +96,13 @@ ObjectId.prototype.toArray = function () {
 * Turns a WCF representation of a BSON ObjectId into a 24 character string representation.
 */
 ObjectId.prototype.toString = function () {
+    if (this.timestamp === undefined
+        || this.machine === undefined
+        || this.pid === undefined
+        || this.increment === undefined) {
+        return 'Invalid ObjectId';
+    }
+
     var timestamp = this.timestamp.toString(16);
     var machine = this.machine.toString(16);
     var pid = this.pid.toString(16);


### PR DESCRIPTION
We at [Zaption](http://www.zaption.com) have been using ObjectId.js on Node. It works pretty well, but had a few persistent crashes (which are annoying on Node because they down the entire process). We fixed them a while back, but I thought it'd be good to contribute them back to the source.
- Fix crash when stringifying an invalid ObjectId (returns `Invalid ObjectId` instead, similar behavior to the JS Date object when stringifying an invalid Date)
- Works without a `document` global, which Node doesn't have, by faking it
