### PR TITLE
Make cookies actually work (and fix various issues with them)

### DIFF
--- a/src/main/javascript/Objectid.js
+++ b/src/main/javascript/Objectid.js
@@ -22,8 +22,9 @@ var ObjectId = (function () {
         var cookieList = document.cookie.split('; ');
         for (var i in cookieList) {
             var cookie = cookieList[i].split('=');
-            if (cookie[0] == 'mongoMachineId' && cookie[1] >= 0 && cookie[1] <= 16777215) {
-                machine = cookie[1];
+            var cookieMachineId = parseInt(cookie[1], 10);
+            if (cookie[0] == 'mongoMachineId' && cookieMachineId && cookieMachineId >= 0 && cookieMachineId <= 16777215) {
+                machine = cookieMachineId;
                 break;
             }
         }

--- a/src/main/javascript/Objectid.js
+++ b/src/main/javascript/Objectid.js
@@ -18,15 +18,7 @@ var ObjectId = (function () {
     var pid = Math.floor(Math.random() * (32767));
     var machine = Math.floor(Math.random() * (16777216));
 
-    if (typeof (localStorage) != 'undefined') {
-        var mongoMachineId = parseInt(localStorage['mongoMachineId']);
-        if (mongoMachineId >= 0 && mongoMachineId <= 16777215) {
-            machine = Math.floor(localStorage['mongoMachineId']);
-        }
-        // Just always stick the value in.
-        localStorage['mongoMachineId'] = machine;
-    }
-    else {
+    var setMachineCookie = function() {
         var cookieList = document.cookie.split('; ');
         for (var i in cookieList) {
             var cookie = cookieList[i].split('=');
@@ -36,7 +28,21 @@ var ObjectId = (function () {
             }
         }
         document.cookie = 'mongoMachineId=' + machine + ';expires=Tue, 19 Jan 2038 05:00:00 GMT;path=/';
-
+    };
+    if (typeof (localStorage) != 'undefined') {
+        try {
+            var mongoMachineId = parseInt(localStorage['mongoMachineId']);
+            if (mongoMachineId >= 0 && mongoMachineId <= 16777215) {
+                machine = Math.floor(localStorage['mongoMachineId']);
+            }
+            // Just always stick the value in.
+            localStorage['mongoMachineId'] = machine;
+        } catch (e) {
+            setMachineCookie();
+        }
+    }
+    else {
+        setMachineCookie();
     }
 
     function ObjId() {

--- a/src/main/javascript/Objectid.js
+++ b/src/main/javascript/Objectid.js
@@ -25,7 +25,6 @@ var ObjectId = (function () {
         }
         // Just always stick the value in.
         localStorage['mongoMachineId'] = machine;
-        document.cookie = 'mongoMachineId=' + machine + ';expires=Tue, 19 Jan 2038 05:00:00 GMT'
     }
     else {
         var cookieList = document.cookie.split('; ');
@@ -36,7 +35,7 @@ var ObjectId = (function () {
                 break;
             }
         }
-        document.cookie = 'mongoMachineId=' + machine + ';expires=Tue, 19 Jan 2038 05:00:00 GMT';
+        document.cookie = 'mongoMachineId=' + machine + ';expires=Tue, 19 Jan 2038 05:00:00 GMT;path=/';
 
     }
 


### PR DESCRIPTION
We noticed some undesired behavior with cookies when using ObjectId.js. This pull request has two commits that reduce cookie waste and fix a crash on Safari Private Mode (and other browsers with localStorage defined but disabled).
- Set one ObjectId cookie for an entire website instead of one per page, to be more true to the mongoMachineId name. We were previously getting one set per page on our site the user visited, which eventually resulted in a cookie string so long that pages were failing to load!
- Don't set a cookie if localStorage works
- If localStorage is defined but disabled, or Safari is in Private Mode, trying to set the value will throw a `QuotaExceededError`, which currently is crashing the page. Instead, we should handle this case and use cookies instead.
