### PR TITLE
Fixed issue in IE10 causing "redeclaration of const property"

### DIFF
--- a/src/main/javascript/Objectid.js
+++ b/src/main/javascript/Objectid.js
@@ -9,13 +9,17 @@
 *
 */
 
-if (!document) var document = { cookie: '' }; // fix crashes on node
-
 /**
  * Javascript class that mimics how WCF serializes a object of type MongoDB.Bson.ObjectId
  * and converts between that format and the standard 24 character representation.
 */
 var ObjectId = (function () {
+
+    // Fix crashes on node
+    if (!document) {
+        var document = { cookie: '' };
+    }
+
     var increment = Math.floor(Math.random() * (16777216));
     var pid = Math.floor(Math.random() * (65536));
     var machine = Math.floor(Math.random() * (16777216));


### PR DESCRIPTION
The NodeJS fix isn't liked in IE. Moving it inside the closure allows `document` to be set locally only.  
